### PR TITLE
Removed usage of sb-pcl because it is deprecated now and sb-mop should be used instead

### DIFF
--- a/src/serialization/serialization.lisp
+++ b/src/serialization/serialization.lisp
@@ -79,8 +79,6 @@
     (mapcar #'car (if (symbolp (caar slots)) slots (cdr slots))))
   #+cmu
   (mapcar #'pcl:slot-definition-name (pcl:class-slots (class-of object)))
-  #+sbcl
-  (mapcar #'sb-pcl:slot-definition-name (sb-pcl:class-slots (class-of object)))
   #+lispworks
   (structure:structure-class-slot-names (class-of object))
   #+allegro
@@ -103,8 +101,6 @@
 	   (class-of object)))
   #+cmu
   (mapcar #'pcl:slot-definition-name (pcl:class-slots (class-of object)))
-  #+sbcl
-  (mapcar #'sb-pcl:slot-definition-name (sb-pcl:class-slots (class-of object)))
   #+lispworks
   (mapcar #'hcl:slot-definition-name (hcl:class-slots (class-of object)))
   #+allegro


### PR DESCRIPTION
This commit closes issue https://github.com/40ants/cl-prevalence/issues/10