### PR TITLE
Add sexp serializer for pathnames.

### DIFF
--- a/src/serialization/sexp.lisp
+++ b/src/serialization/sexp.lisp
@@ -41,6 +41,10 @@
   (declare (ignore serialization-state))
   (write-string "T" stream))
 
+(defmethod serialize-sexp-internal ((object pathname) stream serialization-state)
+  (declare (ignore serialization-state))
+  (prin1 object stream))
+
 (defmethod serialize-sexp-internal ((object string) stream serialization-state)
   (declare (ignore serialization-state))
   (prin1 object stream))

--- a/test/test-serialization.lisp
+++ b/test/test-serialization.lisp
@@ -188,6 +188,11 @@
    (equal (serialize-and-deserialize-sexp "Hello <foo> & </bar>!")
 	  "Hello <foo> & </bar>!")))
 
+(test test-primitive-31
+  (is
+   (equal (serialize-and-deserialize-sexp #P"path/name")
+	  #P"path/name")))
+
 ;; simple sequences
 
 (test test-simple-sequences-1


### PR DESCRIPTION
The test passes when run manually, but I haven't run the test suite because `,test-system` only loads the system.  I think the .asd is missing a `:in-order-to ((test-op ...))` and `:perform (asdf:test-op ...)`.