### PR TITLE
Fiveam testsuite now is a keyword which makes it easier to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           ~/.roswell/bin/qlot exec ros run \
                        --eval '(ql:quickload :cl-prevalence-test)' \
-                       --eval '(uiop:quit (fiveam:run-all-tests))'
+                       --eval '(uiop:quit (fiveam:run! :cl-prevalence))'

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,18 @@ CL-PREVALENCE
 
 This fork is available from Quicklisp and Ultralisp.org.
 
+Running tests
+-------------
+
+To run all tests, eval this in the REPL:
+
+```
+(asdf:test-system :cl-prevalence)
+```
+
+GitHub should run the testsuite for each pull-request automatically.
+
+
 History
 -------
 

--- a/cl-prevalence-test.asd
+++ b/cl-prevalence-test.asd
@@ -14,4 +14,6 @@
                  (:file "test-prevalence")
                  (:file "test-managed-prevalence")
                  (:file "test-master-slave")
-                 (:file "test-serialization")))))
+                 (:file "test-serialization"))))
+  :perform (test-op (o c)
+             (symbol-call :fiveam :run! :cl-prevalence)) )

--- a/cl-prevalence.asd
+++ b/cl-prevalence.asd
@@ -31,4 +31,5 @@
                  (:file "prevalence" :depends-on ("serialization"))
                  (:file "managed-prevalence" :depends-on ("prevalence"))
                  (:file "master-slave" :depends-on ("prevalence"))
-                 (:file "blob" :depends-on ("managed-prevalence"))))))
+                 (:file "blob" :depends-on ("managed-prevalence")))))
+  :in-order-to ((test-op (test-op "cl-prevalence-test"))))

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -7,6 +7,4 @@
   )
 (in-package :cl-prevalence-test)
 
-(def-suite cl-prevalence-test)
-
-
+(def-suite :cl-prevalence)

--- a/test/test-managed-prevalence.lisp
+++ b/test/test-managed-prevalence.lisp
@@ -13,7 +13,7 @@
 ;;;; (http://opensource.franz.com/preamble.html), also known as the LLGPL.
 (in-package :cl-prevalence-test)
 
-(def-suite test-managed-prevalence :in cl-prevalence-test)
+(def-suite test-managed-prevalence :in :cl-prevalence)
 
 (in-suite test-managed-prevalence)
 

--- a/test/test-master-slave.lisp
+++ b/test/test-master-slave.lisp
@@ -12,7 +12,7 @@
 
 (in-package :cl-prevalence-test)
 
-(def-suite test-master-slave :in cl-prevalence-test)
+(def-suite test-master-slave :in :cl-prevalence)
 
 (in-suite test-master-slave)
 

--- a/test/test-prevalence.lisp
+++ b/test/test-prevalence.lisp
@@ -12,7 +12,7 @@
 
 (in-package :cl-prevalence-test)
 
-(def-suite test-prevalence :in cl-prevalence-test)
+(def-suite test-prevalence :in :cl-prevalence)
 
 (in-suite test-prevalence)
 

--- a/test/test-serialization.lisp
+++ b/test/test-serialization.lisp
@@ -12,7 +12,7 @@
 
 (in-package :cl-prevalence-test)
 
-(def-suite test-serialization :in cl-prevalence-test)
+(def-suite test-serialization :in :cl-prevalence)
 
 (in-suite test-serialization)
 


### PR DESCRIPTION
```
(fiveam:run! :cl-prevalence)
```
Also, a necessary ASDF keywords were added and now system can be tested like:

```
(asdf:test-system :cl-prevalence)
```