### PR TITLE
Slot customization

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -15,7 +15,9 @@
   (:export
    #:serializable-slots
    #:serialize-xml #:serialize-sexp
+   #:serialize-xml-slot #:serialize-sexp-slot
    #:deserialize-xml #:deserialize-sexp
+   #:deserialize-sexp-slot              ; TODO: Enable XML custom slot deserialization.
    #:make-serialization-state
    #:reset-known-slots)
   (:documentation "XML and s-expression based serialization for Common Lisp and CLOS"))

--- a/src/serialization/sexp.lisp
+++ b/src/serialization/sexp.lisp
@@ -241,15 +241,15 @@
                    (rplacd conspair (deserialize-sexp-internal cons-cdr deserialized-objects)))))
         (:ref (gethash (rest sexp) deserialized-objects)))))
 
-(defgeneric deserialize-class (class-symbol slots serialization-state)
-  (:documentation "Read and return an s-expression serialized version of a Lisp class from stream."))
+(defgeneric deserialize-class (class-symbol slots deserialized-objects)
+  (:documentation "Read and return an the instance corresponding to CLASS-SYMBOL with SLOTS."))
 
 (defmethod deserialize-class ((class-symbol t) slots deserialized-objects)
   (let ((object (make-instance class-symbol)))
     object))
 
-(defgeneric deserialize-struct (struct-symbol slots serialization-state)
-  (:documentation "Read and return an s-expression serialized version of a Lisp struct from stream."))
+(defgeneric deserialize-struct (struct-symbol slots deserialized-objects)
+  (:documentation "Read and return an the instance corresponding to STRUCT-SYMBOL with SLOTS."))
 
 (defmethod deserialize-struct ((struct-symbol t) slots deserialized-objects)
   (let* ((constructor (intern (concatenate 'string "MAKE-" (symbol-name struct-symbol))

--- a/src/serialization/xml.lisp
+++ b/src/serialization/xml.lisp
@@ -16,6 +16,12 @@
 (defgeneric serialize-xml-internal (object stream serialization-state)
   (:documentation "Write a serialized version of object to stream using XML"))
 
+(defgeneric serialize-xml-slot (object slot-name stream serialization-state)
+  (:documentation "Write a serialized version of OBJECT's SLOT-NAME to STREAM using XML.")
+  (:method ((object standard-object) slot-name stream serialization-state)
+    (serialize-xml-internal (slot-value object slot-name)
+                            stream serialization-state)))
+
 (defun print-symbol-xml (symbol stream)
   (let ((package (symbol-package symbol))
 	(name (prin1-to-string symbol)))
@@ -192,7 +198,7 @@
                     (write-string "<SLOT NAME=\"" stream)
                     (print-symbol-xml slot stream)
                     (write-string "\">" stream)
-                    (serialize-xml-internal (slot-value object slot) stream serialization-state)
+                    (serialize-xml-slot object slot stream serialization-state)
                     (write-string "</SLOT>" stream)))
 	(write-string "</OBJECT>" stream)))))
 

--- a/test/test-serialization.lisp
+++ b/test/test-serialization.lisp
@@ -305,6 +305,23 @@
 	     (equal (get-bar foobar) (get-bar *foobar*))
 	     (eq (class-of foobar) (class-of *foobar*))))))
 
+(defclass custom-foobar ()
+  ((foo :accessor get-foo :initarg :foo)
+   (bar :accessor get-bar :initarg :bar)))
+
+(defparameter *custom-foobar* (make-instance 'foobar :foo 200 :bar 300))
+
+(defmethod serialize-slot-sexp ((object custom-foobar) (slot (eql 'bar)) stream serialization-state)
+  (princ-to-string (slot-value object 'bar)))
+(defmethod deserialize-slot-sexp ((object custom-foobar) (slot (eql 'bar)) stream serialization-state)
+  (read-from-string (slot-value object 'bar)))
+
+(test test-custom-objects-1
+  (let ((custom-foobar (serialize-and-deserialize-sexp *custom-foobar*)))
+    (is (and (equal (get-foo custom-foobar) (get-foo *custom-foobar*))
+	     (equal (get-bar custom-foobar) (get-bar *custom-foobar*))
+	     (eq (class-of custom-foobar) (class-of *custom-foobar*))))))
+
 ;; standard structs
 
 (defstruct foobaz


### PR DESCRIPTION
Fixes #20.

Note that the XML counterpart is missing for desererialization, because the API does not match that of the s-exp backend.

Shall we unexport deserialize-sexp-slot then?