### PR TITLE
Set slots at make-instance time

### DIFF
--- a/cl-prevalence.asd
+++ b/cl-prevalence.asd
@@ -18,7 +18,8 @@
   :licence "Lesser Lisp General Public License"
   :description "Common Lisp Prevalence Package"
   :long-description "Common Lisp Prevalence is an implementation of Object Prevalence for Common Lisp"
-  :depends-on ("s-xml"
+  :depends-on ("closer-mop"
+               "s-xml"
                "s-sysdeps")
   :components 
   ((:module "src"

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -11,7 +11,7 @@
 ;;;; (http://opensource.franz.com/preamble.html), also known as the LLGPL.
 
 (defpackage :s-serialization
-  (:use :cl)
+  (:use :c2cl)
   (:export
    #:serializable-slots
    #:serialize-xml #:serialize-sexp

--- a/src/serialization/sexp.lisp
+++ b/src/serialization/sexp.lisp
@@ -313,12 +313,8 @@ s-expressions."))
     object))
 
 (defgeneric deserialize-sexp-slot (class slot-name slot-value deserialized-objects)
-  (:documentation "Read and return SLOT-VALUE, which corresponds to CLASS's SLOT-NAME. "))
+  (:documentation "Read and return SLOT-VALUE, which corresponds to CLASS's SLOT-NAME."))
 
-(defmethod deserialize-sexp-slot ((object standard-object) slot-name slot-value deserialized-objects)
-  (declare (ignore object slot-name))
-  (deserialize-sexp-internal slot-value deserialized-objects))
-
-(defmethod deserialize-sexp-slot ((object structure-object) slot-name slot-value deserialized-objects)
-  (declare (ignore object slot-name))
+(defmethod deserialize-sexp-slot ((target t) slot-name slot-value deserialized-objects)
+  (declare (ignore target slot-name))
   (deserialize-sexp-internal slot-value deserialized-objects))

--- a/src/serialization/sexp.lisp
+++ b/src/serialization/sexp.lisp
@@ -249,6 +249,47 @@ s-expressions."))
                    (rplacd conspair (deserialize-sexp-internal cons-cdr deserialized-objects)))))
         (:ref (gethash (rest sexp) deserialized-objects)))))
 
+(defun get-class (class-specifier)
+  (if (classp class-specifier)
+      class-specifier
+      (find-class class-specifier)))
+
+(defgeneric get-slot-definition (class slot-name) ; From moptilities
+  (:documentation "Returns the slot-definition for the slot named `slot-name` in the class specified by `class-specifier`. Also returns \(as a second value\) true if the slot is an indirect slot of the class.")
+  (:method ((class-specifier t) slot-name)
+    (let ((class (get-class class-specifier)))
+      (let* ((indirect-slot? nil)
+             (slot-info
+               (or (find slot-name (class-direct-slots class)
+                         :key #'slot-definition-name)
+                   (and (setf indirect-slot? t)
+                        (find slot-name (class-slots class)
+                              :key #'slot-definition-name)))))
+        (values slot-info indirect-slot?)))))
+
+(defgeneric slot-properties (class-specifier slot-name) ; From moptilities
+  (:documentation "Returns a property list describing the slot named slot-name in class-specifier.")
+  (:method ((class symbol) slot-name)
+           (slot-properties (find-class class) slot-name))
+  (:method ((object standard-object) slot-name)
+           (slot-properties (class-of object) slot-name))
+  (:method ((class class) slot-name)
+           (declare (ignorable slot-name))
+           (multiple-value-bind (slot-info indirect-slot?)
+                                (get-slot-definition class slot-name)
+             `(:name ,(slot-definition-name slot-info)
+                     ,@(when (eq (slot-definition-allocation slot-info) :class)
+                         `(:allocation ,(slot-definition-allocation slot-info)))
+                     :initargs ,(slot-definition-initargs slot-info)
+                     :initform ,(slot-definition-initform slot-info)
+                     ,@(when (and (not (eq (slot-definition-type slot-info) t))
+                                  (not (eq (slot-definition-type slot-info) nil)))
+                         `(:type ,(slot-definition-type slot-info)))
+                     ,@(unless indirect-slot?
+                         `(:readers ,(slot-definition-readers slot-info)
+                                    :writers ,(slot-definition-writers slot-info)))
+                     :documentation ,(documentation slot-info t)))))
+
 (defgeneric deserialize-class (class-symbol slots deserialized-objects)
   (:documentation "Read and return an the instance corresponding to CLASS-SYMBOL with SLOTS."))
 

--- a/test/test-serialization.lisp
+++ b/test/test-serialization.lisp
@@ -322,6 +322,18 @@
 	     (equal (get-bar custom-foobar) (get-bar *custom-foobar*))
 	     (eq (class-of custom-foobar) (class-of *custom-foobar*))))))
 
+(defclass foobar-reqarg ()
+  ((foo :accessor get-foo :initarg :foo :initform (error "foo arg required"))
+   (bar :accessor get-bar :initarg :bar)))
+
+(defparameter *foobar-reqarg* (make-instance 'foobar-reqarg :foo 1000 :bar "Bar"))
+
+(test test-reqarg-objects-1
+  (let ((foobar (serialize-and-deserialize-sexp *foobar-reqarg*)))
+    (is (and (equal (get-foo foobar) (get-foo *foobar-reqarg*))
+	     (equal (get-bar foobar) (get-bar *foobar-reqarg*))
+	     (eq (class-of foobar) (class-of *foobar-reqarg*))))))
+
 ;; standard structs
 
 (defstruct foobaz


### PR DESCRIPTION
This changes a few things:

- Drag closer-mop as a dependency.
- Generalize `deserialize-sexp-slot` to work on non-object, non-struct.
- This fixes deserialization of classes with slots that raise an error in the
initform.  See test case for an example.

- Slots that don't have an initarg are set as before, but using the `writer' if
available.
